### PR TITLE
Fix for the JAR Manifest file path on Windows

### DIFF
--- a/src/Jar.js
+++ b/src/Jar.js
@@ -3,6 +3,7 @@
 var archive = require("ls-archive")
   , inherits = require("util").inherits
   , EventEmitter = require("events").EventEmitter
+  , path = require("path")
 
 /**
  * Information about a jar file.
@@ -24,7 +25,7 @@ var Jar = module.exports = function (jarPath) {
      */
     this._manifest = null
 
-    Jar._readJarFile(jarPath, "META-INF/MANIFEST.MF", function (err, manifestData) {
+    Jar._readJarFile(jarPath, path.normalize("META-INF/MANIFEST.MF"), function (err, manifestData) {
         if (err) return this.emit("error", err)
 
         try {


### PR DESCRIPTION
Hey :)

I was getting this error, trying to use node-nailgun on Windows:

```
Error: META-INF/MANIFEST.MF does not exist in the archive: ...
```

Turns out jarfile was causing it because of the forward slash in `META-INF/MANIFEST.MF`.

So, this fix should do the trick on any platform.
